### PR TITLE
Implemented obtaining of the size for generated images

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,8 +48,14 @@ export default function imageSizeLoader(content) {
     regExp: options.regExp,
   });
 
-  const image = sizeOf(this.resourcePath);
-  image.bytes = fs.statSync(this.resourcePath).size;
+  let image;
+  if (this.resourcePath) {
+      image = sizeOf(this.resourcePath);
+      image.bytes = fs.statSync(this.resourcePath).size;
+  } else {
+      image = sizeOf(content);
+      image.bytes = content.byteLength;
+  }
 
   let outputPath = url;
 

--- a/src/index.js
+++ b/src/index.js
@@ -50,11 +50,11 @@ export default function imageSizeLoader(content) {
 
   let image;
   if (this.resourcePath) {
-      image = sizeOf(this.resourcePath);
-      image.bytes = fs.statSync(this.resourcePath).size;
+    image = sizeOf(this.resourcePath);
+    image.bytes = fs.statSync(this.resourcePath).size;
   } else {
-      image = sizeOf(content);
-      image.bytes = content.byteLength;
+    image = sizeOf(content);
+    image.bytes = content.byteLength;
   }
 
   let outputPath = url;


### PR DESCRIPTION
My project uses image generation, which makes it impossible to get the `resourcePath` - it simply doesn't exist. However, if you use a raw buffer value, everything works as expected.